### PR TITLE
refactor: html meta tag strategy

### DIFF
--- a/src/Factories/VerifierFactory.php
+++ b/src/Factories/VerifierFactory.php
@@ -4,7 +4,7 @@ namespace SunAsterisk\DomainVerifier\Factories;
 
 use SunAsterisk\DomainVerifier\Contracts\Strategies\StrategyInterface;
 use SunAsterisk\DomainVerifier\Strategies\DNSRecord;
-use SunAsterisk\DomainVerifier\Strategies\HTML;
+use SunAsterisk\DomainVerifier\Strategies\HTMLMeta;
 use SunAsterisk\DomainVerifier\Strategies\HTMLFile;
 use SunAsterisk\DomainVerifier\Strategies\Mail;
 
@@ -20,7 +20,7 @@ class VerifierFactory
                 return new HTMLFile();
                 break;
             case 'html-meta':
-                return new HTML();
+                return new HTMLMeta();
                 break;
             case 'mail':
                 return new Mail();

--- a/src/Models/DomainVerification.php
+++ b/src/Models/DomainVerification.php
@@ -31,4 +31,19 @@ class DomainVerification extends Model
 
         return $this;
     }
+
+    /**
+     * Unverify domain
+     *
+     * @return DomainVerification
+     */
+    public function setNotVerified()
+    {
+        $this->update([
+            'verified_at' => null,
+            'status' => 'pending',
+        ]);
+
+        return $this;
+    }
 }

--- a/src/Strategies/BaseStrategy.php
+++ b/src/Strategies/BaseStrategy.php
@@ -11,6 +11,13 @@ abstract class BaseStrategy implements StrategyInterface
 {
     abstract public function verify(string $url, DomainVerifiableInterface $domainVerifiable): VerifyResult;
 
+    /**
+     * Get token for verification process
+     *
+     * @param  string  $url
+     * @param  DomainVerifiableInterface  $domainVerifiable
+     * @return string
+     */
     public function getToken(string $url, DomainVerifiableInterface $domainVerifiable): string
     {
         $record = DomainVerificationFacade::firstOrCreate($url, $domainVerifiable);

--- a/src/Strategies/HTMLFile.php
+++ b/src/Strategies/HTMLFile.php
@@ -13,9 +13,9 @@ class HTMLFile extends BaseStrategy
     /**
      * Verify domain ownership via HTML meta tag
      *
-     * @param string $url
-     * @param DomainVerifiableInterface $domainVerifiable
-     * @return bool
+     * @param  string  $url
+     * @param  DomainVerifiableInterface  $domainVerifiable
+     * @return VerifyResult
      */
     public function verify(string $url, DomainVerifiableInterface $domainVerifiable): VerifyResult
     {
@@ -25,6 +25,8 @@ class HTMLFile extends BaseStrategy
 
         if ($domainToken === $verificationToken) {
             $record->setVerified();
+        } else {
+            $record->setNotVerified();
         }
 
         return new VerifyResult($domainVerifiable, $url, $record);

--- a/src/Strategies/HTMLMeta.php
+++ b/src/Strategies/HTMLMeta.php
@@ -8,23 +8,25 @@ use SunAsterisk\DomainVerifier\Contracts\Strategies\StrategyInterface;
 use SunAsterisk\DomainVerifier\DomainVerificationFacade;
 use SunAsterisk\DomainVerifier\Results\VerifyResult;
 
-class HTML extends BaseStrategy
+class HTMLMeta extends BaseStrategy
 {
     /**
      * Verify domain ownership via HTML meta tag
      *
-     * @param string $url
-     * @param DomainVerifiableInterface $domainVerifiable
-     * @return bool
+     * @param  string  $url
+     * @param  DomainVerifiableInterface  $domainVerifiable
+     * @return VerifyResult
      */
-    public function verify(string $url, DomainVerifiableInterface $domainVerifiable)
+    public function verify(string $url, DomainVerifiableInterface $domainVerifiable): VerifyResult
     {
         $metaTags = $this->getMetaTags($url);
-        $domainToken = $this->getToken($metaTags);
+        $domainToken = $this->getMetaTagToken($metaTags);
         $record = DomainVerificationFacade::firstOrCreate($url, $domainVerifiable);
 
         if ($record->token === $domainToken) {
             $record->setVerified();
+        } else {
+            $record->setNotVerified();
         }
 
         return new VerifyResult($domainVerifiable, $url, $record);
@@ -35,9 +37,8 @@ class HTML extends BaseStrategy
         return get_meta_tags($url);
     }
 
-    protected function getToken(array $metaTags)
+    protected function getMetaTagToken(array $metaTags)
     {
-        // do somethings
         $verificationName = config('domain_verifier.verification_name');
         if (!isset($metaTags[$verificationName])) {
             return '';


### PR DESCRIPTION
- Rename `HTML` strategy to `HTMLMeta`, rename `getToken` protected method to `getMetaTagToken`.
- Add `setNotVerified()` method to `DomainVerification` model.
- Add some more PHPDoc.